### PR TITLE
Legacy compose add custom spans

### DIFF
--- a/app/src/main/java/com/mamboa/FirstFragment.kt
+++ b/app/src/main/java/com/mamboa/FirstFragment.kt
@@ -9,6 +9,7 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.MaskFilterSpan
 import android.text.style.StrikethroughSpan
 import android.text.style.SuperscriptSpan
+import android.text.style.UnderlineSpan
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -63,7 +64,7 @@ class FirstFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        test1()
+        test2()
 
         binding.buttonFirst.setOnClickListener {
             findNavController().navigate(R.id.action_FirstFragment_to_SecondFragment)
@@ -224,6 +225,40 @@ class FirstFragment : Fragment() {
 //                .setTextStyle(Typeface.BOLD)
                 .setTextSize(R.dimen.test_default_text_size)
 //                .setFont(R.font.ocean_summer)
+                .build()
+                .create()
+    }
+
+    fun test2() {
+        val text = "Praesent tempus nibh ac ante aliquet suscipit. Praesent ex lectus, dapibus non porttitor id, aliquet nec sem."
+        val tempus = "tempus"
+        val blurMask = BlurMaskFilter(5f, BlurMaskFilter.Blur.NORMAL)
+        binding.textviewFirst.text =
+            EasySpans.Builder(requireContext(), text, binding.textviewFirst)
+                .addSpan { UnderlineSpan()  }
+                .setOccurrenceChunks(
+                    OccurrenceChunk(
+                        location = OccurrenceLocation(
+                            DelimitationType.REGEX(tempus),
+                            OccurrencePosition.All
+                        ),
+                        builder = OccurrenceChunkBuilder()
+                            .setColor(android.R.color.holo_red_dark)
+                            .addSpan { StrikethroughSpan() }
+                            .addSpan { MaskFilterSpan(blurMask) }
+                            .setOnLinkClickListener(
+                                object : ClickableLinkSpan.OnLinkClickListener {
+                                    override fun onLinkClick(view: View) {
+                                        Snackbar.make(
+                                            binding.root,
+                                            "$tempus clicked",
+                                            Snackbar.LENGTH_SHORT
+                                        ).show()
+                                    }
+                                }
+                            ),
+                    )
+                )
                 .build()
                 .create()
     }

--- a/app/src/main/java/com/mamboa/FirstFragment.kt
+++ b/app/src/main/java/com/mamboa/FirstFragment.kt
@@ -1,10 +1,19 @@
 package com.mamboa
 
+import android.graphics.BlurMaskFilter
 import android.graphics.Typeface
 import android.os.Bundle
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.text.style.MaskFilterSpan
+import android.text.style.StrikethroughSpan
+import android.text.style.SuperscriptSpan
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
@@ -54,7 +63,6 @@ class FirstFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-
         test1()
 
         binding.buttonFirst.setOnClickListener {
@@ -67,7 +75,9 @@ class FirstFragment : Fragment() {
         val trader = "Trader"
         val tempus = "tempus"
         val regex4 = "turpis"
+        val blurMask =  BlurMaskFilter(5f, BlurMaskFilter.Blur.NORMAL)
 
+        Log.d("EasySpans", "Input text: $text")
         binding.textviewFirst.text =
             EasySpans.Builder(requireContext(), text, binding.textviewFirst)
                 .setOccurrenceLocation(
@@ -105,10 +115,16 @@ class FirstFragment : Fragment() {
                     OccurrenceChunk(
                         location = OccurrenceLocation(
                             DelimitationType.REGEX(tempus),
-                            OccurrencePosition.First
+                            OccurrencePosition.All // OccurrencePosition.All
                         ),
                         builder = OccurrenceChunkBuilder()
                             .setColor(android.R.color.holo_red_dark)
+//                            .isStrikeThrough()
+//                            .setScriptType(com.mamboa.easyspans.legacy.helper.ScriptType.SUPER)
+                            //.addSpan { ForegroundColorSpan(ContextCompat.getColor(this@FirstFragment.requireContext(), android.R.color.holo_red_dark)) }
+                            .addSpan { StrikethroughSpan() }
+                            .addSpan { SuperscriptSpan() }
+                            .addSpan { MaskFilterSpan(blurMask) }
                             .setOnLinkClickListener(
                                 object : ClickableLinkSpan.OnLinkClickListener {
                                     override fun onLinkClick(view: View) {
@@ -150,10 +166,10 @@ class FirstFragment : Fragment() {
                              .setTextSize(R.dimen.test_text_size)
                              .setTextStyle(Typeface.BOLD)
                              //.setScriptType(ScriptType.SUPER)
-                             .setFont(R.font.ocean_summer)
+//                             .setFont(com.mamboa.easyspans.legacy.R.font.ocean_summer)
                              .setColor(R.color.purple_500)
                              .setChunkBackgroundColor(R.color.teal_700)
-                             .setTextCaseType(TextCaseSpan.TextCaseType.UPPER_CASE)
+                             .setTextCaseType(TextCaseSpan.TextCaseType.LOWER_CASE)
                              /*.setParagraphBackgroundColor(
                                  SequenceBackgroundColor(
                                      backgroundColor = R.color.purple_700,
@@ -207,7 +223,7 @@ class FirstFragment : Fragment() {
 //                .setChunkBackgroundColor(R.color.teal_200)
 //                .setTextStyle(Typeface.BOLD)
                 .setTextSize(R.dimen.test_default_text_size)
-                .setFont(R.font.ocean_summer)
+//                .setFont(R.font.ocean_summer)
                 .build()
                 .create()
     }

--- a/app/src/main/java/com/mamboa/SecondFragment.kt
+++ b/app/src/main/java/com/mamboa/SecondFragment.kt
@@ -7,11 +7,12 @@ import android.view.ViewGroup
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -30,13 +31,15 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
+import com.mamboa.easyspans.compose.DashPattern
+import com.mamboa.easyspans.compose.DashedDecorationText
 import com.mamboa.easyspans.compose.DelimitationType
-import com.mamboa.easyspans.compose.EasySpansClickableText
 import com.mamboa.easyspans.compose.EasySpansCompose
 import com.mamboa.easyspans.compose.OccurrenceLocation
 import com.mamboa.easyspans.compose.OccurrencePosition
 import com.mamboa.easyspans.compose.ScriptType
 import com.mamboa.easyspans.compose.occurrenceChunk
+import com.mamboa.easyspans.compose.RoundedBackgroundText
 
 class SecondFragment : Fragment() {
 
@@ -72,13 +75,14 @@ class SecondFragment : Fragment() {
                     item {
                         ClickableWords()
                     }
-                    /*
+
                     item {
                         Spacer(modifier = Modifier.height(16.dp))
                     }
                     item {
                         UppercaseNthWord()
                     }
+                    /*
                     item {
                         Spacer(modifier = Modifier.height(16.dp))
                     }
@@ -160,7 +164,18 @@ fun FirstWordStyled() {
 
 @Composable
 fun ClickableWords() {
-    val annotatedString = EasySpansCompose("Click here, there, or now!") {
+    RoundedBackgroundText(
+        text = "Hello World! Hello Compose!\nHello World! Hello Compose!\nHello World! Hello Compose!",
+        backgroundColor = Color.Blue.copy(alpha = 0.5f),
+        cornerRadius = 8.dp,
+        horizontalPadding = 4.dp,
+        verticalPadding = 6.dp,
+        occurrenceLocation = OccurrenceLocation(
+            delimitationType = DelimitationType.Boundary(" "),
+            occurrencePosition = OccurrencePosition.Last
+        )
+    )
+    /*val annotatedString = EasySpansCompose("Click here, there, or now!") {
         setColor(Color.Black)
         setOccurrenceChunks(
             occurrenceChunk(
@@ -217,12 +232,27 @@ fun ClickableWords() {
             }
         },
         style = MaterialTheme.typography.bodyLarge,
-    )
+    )*/
 }
 
 @Composable
 fun UppercaseNthWord() {
-    val annotatedString = EasySpansCompose("hello world! hello compose!") {
+    DashedDecorationText(
+        text = "Hello World! This is a test.",
+        dashedUnderline = true,
+        dashedStrikethrough = true,
+        dashPattern = DashPattern.DASH_DOT,
+        dashWidth = 4.dp,
+        dashGap = 2.dp,
+        lineColor = Color.Blue,
+        lineThickness = 1.dp,
+        occurrenceLocation = OccurrenceLocation(
+            delimitationType = DelimitationType.Boundary(" "),
+            occurrencePosition = OccurrencePosition.First
+        )
+    )
+
+    /*val annotatedString = EasySpansCompose("hello world! hello compose!") {
         setTextCase { it.uppercase() }
         setColor(Color.Black)
         addOccurrenceChunk(
@@ -235,7 +265,7 @@ fun UppercaseNthWord() {
             )
         )
     }
-    Text(text = annotatedString)
+    Text(text = annotatedString)*/
 }
 
 @Composable

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/SecondFragment">
+    app:startDestination="@id/FirstFragment">
 
     <fragment
         android:id="@+id/FirstFragment"

--- a/compose/src/main/java/com/mamboa/easyspans/compose/DashedDecorationText.kt
+++ b/compose/src/main/java/com/mamboa/easyspans/compose/DashedDecorationText.kt
@@ -21,7 +21,7 @@ enum class DashPattern {
 }
 
 @Composable
-fun DashedDecorationText(
+internal fun DashedDecorationText(
     text: String,
     modifier: Modifier = Modifier,
     dashedUnderline: Boolean = false,

--- a/compose/src/main/java/com/mamboa/easyspans/compose/DashedDecorationText.kt
+++ b/compose/src/main/java/com/mamboa/easyspans/compose/DashedDecorationText.kt
@@ -1,0 +1,122 @@
+package com.mamboa.easyspans.compose
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+enum class DashPattern {
+    LINE,
+    DOT,
+    DASH,
+    DASH_DOT,
+    CUSTOM
+}
+
+@Composable
+fun DashedDecorationText(
+    text: String,
+    modifier: Modifier = Modifier,
+    dashedUnderline: Boolean = false,
+    dashedStrikethrough: Boolean = false,
+    dashPattern: DashPattern = DashPattern.DOT,
+    dashWidth: Dp = 4.dp,
+    dashGap: Dp = 2.dp,
+    lineColor: Color = Color.Black,
+    lineThickness: Dp = 1.dp,
+    customPattern: List<Float>? = null,
+    occurrenceLocation: OccurrenceLocation
+) {
+    var textLayoutResult: TextLayoutResult? = null
+
+    val density = LocalDensity.current
+
+    val pattern = with(density) {
+        when (dashPattern) {
+            DashPattern.LINE -> floatArrayOf(Float.POSITIVE_INFINITY, 0f)
+            DashPattern.DOT -> floatArrayOf(2f, dashGap.toPx())
+            DashPattern.DASH -> floatArrayOf(dashWidth.toPx(), dashGap.toPx())
+            DashPattern.DASH_DOT -> floatArrayOf(
+                dashWidth.toPx(),
+                dashGap.toPx(),
+                2f,
+                dashGap.toPx()
+            )
+            DashPattern.CUSTOM -> customPattern?.toFloatArray()
+                ?: floatArrayOf(dashWidth.toPx(), dashGap.toPx())
+        }
+    }
+
+    val annotatedString = EasySpansCompose(text) {
+        addOccurrenceChunk(
+            occurrenceChunk(
+                occurrenceLocation = occurrenceLocation,
+                styleBuilder = { it }
+            )
+        )
+    }
+
+    Text(
+        text = annotatedString,
+        modifier = modifier.drawBehind {
+            textLayoutResult?.let { layoutResult ->
+                val ranges = Utils.getOccurrenceRanges(occurrenceLocation, text)
+                val strokeWidthPx = lineThickness.toPx()
+                val pathEffect = PathEffect.dashPathEffect(pattern)
+
+                for (range in ranges) {
+                    val start = range.first
+                    val end = range.last + 1
+                    val startLine = layoutResult.getLineForOffset(start)
+                    val endLine = layoutResult.getLineForOffset(end)
+
+                    for (lineNum in startLine..endLine) {
+                        val lineStart = if (lineNum == startLine) {
+                            layoutResult.getHorizontalPosition(start, true)
+                        } else {
+                            layoutResult.getLineLeft(lineNum)
+                        }
+
+                        val lineEnd = if (lineNum == endLine) {
+                            layoutResult.getHorizontalPosition(end, true)
+                        } else {
+                            layoutResult.getLineRight(lineNum)
+                        }
+
+                        val baseline = layoutResult.getLineBottom(lineNum)
+
+                        if (dashedUnderline) {
+                            drawLine(
+                                color = lineColor,
+                                start = Offset(lineStart, baseline + strokeWidthPx),
+                                end = Offset(lineEnd, baseline + strokeWidthPx),
+                                strokeWidth = strokeWidthPx,
+                                pathEffect = pathEffect
+                            )
+                        }
+
+                        if (dashedStrikethrough) {
+                            val middle = (layoutResult.getLineTop(lineNum) +
+                                    layoutResult.getLineBottom(lineNum)) / 2
+                            drawLine(
+                                color = lineColor,
+                                start = Offset(lineStart, middle),
+                                end = Offset(lineEnd, middle),
+                                strokeWidth = strokeWidthPx,
+                                pathEffect = pathEffect
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        onTextLayout = { textLayoutResult = it }
+    )
+}

--- a/compose/src/main/java/com/mamboa/easyspans/compose/EasySpansCompose.kt
+++ b/compose/src/main/java/com/mamboa/easyspans/compose/EasySpansCompose.kt
@@ -2,15 +2,22 @@ package com.mamboa.easyspans.compose
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.drawscope.DrawStyle
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.PlatformSpanStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontSynthesis
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.intl.LocaleList
 import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextGeometricTransform
 import androidx.compose.ui.unit.TextUnit
 
 /**
@@ -24,7 +31,7 @@ sealed class OccurrencePosition {
     data object Last : OccurrencePosition()
     data object All : OccurrencePosition()
     data class Nth(val n: Int) : OccurrencePosition()
-    data class Indices(val indices: List<Int>) : OccurrencePosition(){
+    data class Indices(val indices: List<Int>) : OccurrencePosition() {
         constructor(vararg positions: Int) : this(positions.toList())
     }
 }
@@ -36,7 +43,19 @@ sealed class OccurrencePosition {
 @Stable
 sealed class DelimitationType {
     data class Boundary(val delimiter: String) : DelimitationType()
-    data class Regex(val pattern: String, val regex: kotlin.text.Regex = kotlin.text.Regex(pattern)) : DelimitationType()
+    data class Regex(
+        val pattern: String,
+        val regex: kotlin.text.Regex = kotlin.text.Regex(pattern)
+    ) : DelimitationType() {
+        constructor(pattern: String, options: Set<RegexOption>) : this(
+            pattern,
+            kotlin.text.Regex(pattern, options)
+        )
+        constructor(pattern: String, dotMatchesAll: RegexOption) : this(
+            pattern = pattern,
+            regex = kotlin.text.Regex(pattern, setOf(dotMatchesAll))
+        )
+    }
 }
 
 /**
@@ -88,7 +107,8 @@ enum class ScriptType {
  */
 @Stable
 class EasySpansComposeBuilder private constructor(
-    private val text: String
+    private val text: String,
+    private var spanStyle: SpanStyle = SpanStyle()
 ) {
     private var color: Color? = null
     private var backgroundColor: Color? = null
@@ -99,6 +119,18 @@ class EasySpansComposeBuilder private constructor(
     private var textDecoration: TextDecoration? = null
     private var textCase: ((String) -> String)? = null
     private var scriptType: ScriptType = ScriptType.NONE
+    private var brush: Brush? = null
+    private var alpha: Float = 1.0f
+    private var fontSynthesis: FontSynthesis? = null
+    private var fontFeatureSettings: String? = null
+    private var letterSpacing: TextUnit? = null
+    private var baselineShift: BaselineShift? = null
+    private var textGeometricTransform: TextGeometricTransform? = null
+    private var localeList: LocaleList? = null
+    private var shadow: Shadow? = null
+    private var platformStyle: PlatformSpanStyle? = null
+    private var drawStyle: DrawStyle? = null
+
     private val occurrenceChunks: MutableList<OccurrenceChunk> = mutableListOf()
     private var occLocation: OccurrenceLocation? = null
     private val spanStyles = mutableListOf<SpanBuilder>()
@@ -116,6 +148,19 @@ class EasySpansComposeBuilder private constructor(
     fun setFontStyle(style: FontStyle) = apply { this.fontStyle = style }
     fun setFontFamily(family: FontFamily) = apply { this.fontFamily = family }
     fun setTextDecoration(decoration: TextDecoration?) = apply { this.textDecoration = decoration }
+    fun setBrush(brush: Brush) = apply { this.brush = brush }
+    fun setAlpha(alpha: Float) = apply { this.alpha = alpha }
+    fun setFontSynthesis(synthesis: FontSynthesis) = apply { this.fontSynthesis = synthesis }
+    fun setFontFeatureSettings(settings: String) = apply { this.fontFeatureSettings = settings }
+    fun setLetterSpacing(spacing: TextUnit) = apply { this.letterSpacing = spacing }
+    fun setBaselineShift(shift: BaselineShift) = apply { this.baselineShift = shift }
+    fun setTextGeometricTransform(transform: TextGeometricTransform) =
+        apply { this.textGeometricTransform = transform }
+
+    fun setLocaleList(localeList: LocaleList) = apply { this.localeList = localeList }
+    fun setShadow(shadow: Shadow) = apply { this.shadow = shadow }
+    fun setPlatformStyle(style: PlatformSpanStyle) = apply { this.platformStyle = style }
+    fun setDrawStyle(style: DrawStyle) = apply { this.drawStyle = style }
     fun setTextCase(case: (String) -> String) = apply { this.textCase = case }
     fun setOccurrenceLocation(location: OccurrenceLocation) = apply { occLocation = location }
     fun addOccurrenceChunk(chunk: OccurrenceChunk) = apply { occurrenceChunks.add(chunk) }
@@ -125,25 +170,67 @@ class EasySpansComposeBuilder private constructor(
         occurrenceChunks.addAll(chunks)
     }
 
+    fun setSpanStyle(spanStyle: SpanStyle) = apply {
+        this.spanStyle = spanStyle
+        // If a span style is set, it will override the global style
+        if (spanStyle != SpanStyle()) {
+            this.color = null
+            this.backgroundColor = null
+            this.fontSize = null
+            this.fontWeight = null
+            this.fontStyle = null
+            this.fontFamily = null
+            this.textDecoration = null
+            this.brush = null
+            this.alpha = 1.0f
+            this.fontSynthesis = null
+            this.fontFeatureSettings = null
+            this.letterSpacing = null
+            this.textGeometricTransform = null
+            this.localeList = null
+            this.shadow = null
+            this.platformStyle = null
+            this.drawStyle = null
+            this.baselineShift = null
+            this.scriptType = ScriptType.NONE
+        }
+    }
+
     /**
      * Builds the global SpanStyle based on the properties set in the builder.
      *
      * @return A SpanStyle that can be applied to the entire text.
      */
-    private fun buildGlobalSpanStyle(): SpanStyle = SpanStyle(
-        color = color ?: Color.Unspecified,
-        fontSize = fontSize ?: TextUnit.Unspecified,
-        fontWeight = fontWeight ?: FontWeight.Normal,
-        fontStyle = fontStyle ?: FontStyle.Normal,
-        fontFamily = fontFamily,
-        baselineShift = when (scriptType) {
-            ScriptType.SUPER -> BaselineShift.Superscript
-            ScriptType.SUB -> BaselineShift.Subscript
-            ScriptType.NONE -> BaselineShift.None
-        },
-        textDecoration = textDecoration,
-        background = backgroundColor ?: Color.Unspecified
-    )
+    private fun buildGlobalSpanStyle(): SpanStyle {
+        // Individual properties override the base spanStyle
+        return spanStyle.merge(
+            SpanStyle(
+                color = color ?: Color.Unspecified,
+                background = backgroundColor ?: Color.Unspecified,
+                fontSize = fontSize ?: TextUnit.Unspecified,
+                fontWeight = fontWeight,
+                fontStyle = fontStyle,
+                fontFamily = fontFamily,
+                textDecoration = textDecoration,
+                fontSynthesis = fontSynthesis ?: FontSynthesis.All,
+                fontFeatureSettings = fontFeatureSettings ?: "",
+                letterSpacing = letterSpacing ?: TextUnit.Unspecified,
+                textGeometricTransform = textGeometricTransform ?: TextGeometricTransform(),
+                localeList = localeList ?: LocaleList.current,
+                shadow = shadow ?: Shadow(),
+                platformStyle = platformStyle ?: PlatformSpanStyle(),
+                drawStyle = drawStyle,
+                baselineShift = when (scriptType) {
+                    ScriptType.SUPER -> BaselineShift.Superscript
+                    ScriptType.SUB -> BaselineShift.Subscript
+                    ScriptType.NONE -> BaselineShift.None
+                }
+            ).copy(
+                brush = brush ?: spanStyle.brush,
+                alpha = alpha.takeIf { it != 1.0f } ?: spanStyle.alpha,
+            )
+        )
+    }
 
     /**
      * Adds a span style to the builder.
@@ -224,7 +311,7 @@ class EasySpansComposeBuilder private constructor(
 
         // Add styles and annotations for each chunk
         for (chunk in processedOccurrenceChunks) {
-            val ranges = getOccurrenceRanges(chunk.occurrenceLocation, displayText)
+            val ranges = Utils.getOccurrenceRanges(chunk.occurrenceLocation, displayText)
             for (range in ranges) {
                 val intRange = range.first until (range.last + 1)
                 // Add style and annotation if the range is not already annotated with a different tag
@@ -245,7 +332,13 @@ class EasySpansComposeBuilder private constructor(
                     chunk.textTransform?.let { transform ->
                         val substring = displayText.substring(range.first, range.last + 1)
                         val transformedText = transform(substring)
-                        textTransformations.add(Triple(range.first, range.last + 1, transformedText))
+                        textTransformations.add(
+                            Triple(
+                                range.first,
+                                range.last + 1,
+                                transformedText
+                            )
+                        )
                     }
                 }
             }
@@ -271,61 +364,31 @@ class EasySpansComposeBuilder private constructor(
             }
             // Sort spanStyles by start index to ensure correct order
             //spanStyles.sortedBy { it.start }.forEach { spanBuilder ->
-            spanStyles.sortedWith(compareBy({ it.start }, { -spanStyles.indexOf(it) })).forEach { spanBuilder ->
-                val start = spanBuilder.start.coerceIn(0, displayText.length)
-                val end = spanBuilder.end.coerceIn(0, displayText.length)
-                if (start < end) {
-                    val style = spanBuilder.styleBuilder(baseStyle)
-                    addStyle(style, start, end)
-                    spanBuilder.clickTag?.let { tag ->
-                        val intRange = start until end
-                        // Only add annotation if this is the intended tag for the range
-                        if (existingAnnotations[intRange] == tag) {
-                            addStringAnnotation(
-                                tag = tag,
-                                annotation = displayText.substring(start, end),
-                                start = start,
-                                end = end
-                            )
+            spanStyles.sortedWith(compareBy({ it.start }, { -spanStyles.indexOf(it) }))
+                .forEach { spanBuilder ->
+                    val start = spanBuilder.start.coerceIn(0, displayText.length)
+                    val end = spanBuilder.end.coerceIn(0, displayText.length)
+                    if (start < end) {
+                        val style = spanBuilder.styleBuilder(baseStyle)
+                        addStyle(style, start, end)
+                        spanBuilder.clickTag?.let { tag ->
+                            val intRange = start until end
+                            // Only add annotation if this is the intended tag for the range
+                            if (existingAnnotations[intRange] == tag) {
+                                addStringAnnotation(
+                                    tag = tag,
+                                    annotation = displayText.substring(start, end),
+                                    start = start,
+                                    end = end
+                                )
+                            }
                         }
                     }
                 }
-            }
         }.also {
             spanStyles.clear()
             clickTags.clear()
             baseStyle = SpanStyle()
-        }
-    }
-
-    /**
-     * Gets the ranges of occurrences based on the specified location and text.
-     * It handles both boundary and regex delimitation types.
-     *
-     * @param location The occurrence location containing delimitation type and position.
-     * @param text The text in which to find occurrences.
-     * @return A list of IntRange representing the positions of occurrences in the text.
-     */
-    private fun getOccurrenceRanges(location: OccurrenceLocation, text: String): List<IntRange> {
-        val delim = location.delimitationType
-        val position = location.occurrencePosition
-        val ranges = when (delim) {
-            is DelimitationType.Boundary -> Utils.getBoundaryRanges(text, delim.delimiter)
-            is DelimitationType.Regex -> {
-                try {
-                    Utils.getRegexMatchRanges(text, delim.regex)
-                } catch (e: Exception) {
-                    // If regex is invalid, skip this chunk
-                    emptyList()
-                }
-            }
-        }
-        return when (position) {
-            is OccurrencePosition.All -> ranges
-            is OccurrencePosition.First -> ranges.take(1)
-            is OccurrencePosition.Last -> ranges.takeLast(1)
-            is OccurrencePosition.Nth -> ranges.getOrNull(position.n)?.let { listOf(it) } ?: emptyList()
-            is OccurrencePosition.Indices -> position.indices.mapNotNull { ranges.getOrNull(it) }
         }
     }
 

--- a/compose/src/main/java/com/mamboa/easyspans/compose/RoundedBackgroundText.kt
+++ b/compose/src/main/java/com/mamboa/easyspans/compose/RoundedBackgroundText.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun RoundedBackgroundText(
+internal fun RoundedBackgroundText(
     text: String,
     modifier: Modifier = Modifier,
     backgroundColor: Color,

--- a/compose/src/main/java/com/mamboa/easyspans/compose/RoundedBackgroundText.kt
+++ b/compose/src/main/java/com/mamboa/easyspans/compose/RoundedBackgroundText.kt
@@ -1,0 +1,138 @@
+package com.mamboa.easyspans.compose
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RoundedBackgroundText(
+    text: String,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color,
+    cornerRadius: Dp = 4.dp,
+    horizontalPadding: Dp = 8.dp,
+    verticalPadding: Dp = 4.dp,
+    occurrenceLocation: OccurrenceLocation,
+    selectable: Boolean = true
+) {
+    var textLayoutResult: TextLayoutResult? = null
+
+    val annotatedString = EasySpansCompose(text) {
+        addOccurrenceChunk(
+            occurrenceChunk(
+                occurrenceLocation = occurrenceLocation,
+                styleBuilder = { it }
+            )
+        )
+    }
+
+    Box(modifier = modifier) {
+        if (selectable) {
+            SelectionContainer {
+                Text(
+                    text = annotatedString,
+                    modifier = Modifier.drawBehind {
+                        textLayoutResult?.let { layoutResult ->
+                            val ranges = Utils.getOccurrenceRanges(occurrenceLocation, text)
+
+                            for (range in ranges) {
+                                val start = range.first
+                                val end = range.last + 1
+                                val lineRanges = layoutResult.getLineRangesForRange(start, end)
+
+                                lineRanges.forEach { (lineStart, lineEnd, top, bottom) ->
+                                    val left = lineStart - horizontalPadding.toPx()
+                                    val right = lineEnd + horizontalPadding.toPx()
+                                    val topY = top - verticalPadding.toPx()
+                                    val bottomY = bottom + verticalPadding.toPx()
+
+                                    drawRoundRect(
+                                        color = backgroundColor,
+                                        topLeft = Offset(left, topY),
+                                        size = androidx.compose.ui.geometry.Size(
+                                            right - left,
+                                            bottomY - topY
+                                        ),
+                                        cornerRadius = CornerRadius(cornerRadius.toPx())
+                                    )
+                                }
+                            }
+                        }
+                    },
+                    onTextLayout = { textLayoutResult = it }
+                )
+            }
+        } else {
+            Text(
+                text = annotatedString,
+                modifier = Modifier.drawBehind {
+                    textLayoutResult?.let { layoutResult ->
+                        val ranges = Utils.getOccurrenceRanges(occurrenceLocation, text)
+
+                        for (range in ranges) {
+                            val start = range.first
+                            val end = range.last + 1
+                            val lineRanges = layoutResult.getLineRangesForRange(start, end)
+
+                            lineRanges.forEach { (lineStart, lineEnd, top, bottom) ->
+                                val left = lineStart - horizontalPadding.toPx()
+                                val right = lineEnd + horizontalPadding.toPx()
+                                val topY = top - verticalPadding.toPx()
+                                val bottomY = bottom + verticalPadding.toPx()
+
+                                drawRoundRect(
+                                    color = backgroundColor,
+                                    topLeft = Offset(left, topY),
+                                    size = androidx.compose.ui.geometry.Size(
+                                        right - left,
+                                        bottomY - topY
+                                    ),
+                                    cornerRadius = CornerRadius(cornerRadius.toPx())
+                                )
+                            }
+                        }
+                    }
+                },
+                onTextLayout = { textLayoutResult = it }
+            )
+        }
+    }
+}
+
+private fun TextLayoutResult.getLineRangesForRange(start: Int, end: Int): List<LineRange> {
+    val startLine = getLineForOffset(start)
+    val endLine = getLineForOffset(end)
+
+    return (startLine..endLine).map { lineIndex ->
+        val lineStart = getHorizontalPosition(
+            offset = if (lineIndex == startLine) start else getLineStart(lineIndex),
+            usePrimaryDirection = true
+        )
+        val lineEnd = getHorizontalPosition(
+            offset = if (lineIndex == endLine) end else getLineEnd(lineIndex),
+            usePrimaryDirection = true
+        )
+        LineRange(
+            lineStart = lineStart,
+            lineEnd = lineEnd,
+            top = getLineTop(lineIndex),
+            bottom = getLineBottom(lineIndex)
+        )
+    }
+}
+
+private data class LineRange(
+    val lineStart: Float,
+    val lineEnd: Float,
+    val top: Float,
+    val bottom: Float
+)

--- a/compose/src/main/java/com/mamboa/easyspans/compose/Utils.kt
+++ b/compose/src/main/java/com/mamboa/easyspans/compose/Utils.kt
@@ -5,6 +5,37 @@ package com.mamboa.easyspans.compose
  */
 object Utils {
     /**
+     * Gets the ranges of occurrences based on the specified location and text.
+     * It handles both boundary and regex delimitation types.
+     *
+     * @param location The occurrence location containing delimitation type and position.
+     * @param text The text in which to find occurrences.
+     * @return A list of IntRange representing the positions of occurrences in the text.
+     */
+    fun getOccurrenceRanges(location: OccurrenceLocation, text: String): List<IntRange> {
+        val delim = location.delimitationType
+        val position = location.occurrencePosition
+        val ranges = when (delim) {
+            is DelimitationType.Boundary -> getBoundaryRanges(text, delim.delimiter)
+            is DelimitationType.Regex -> {
+                try {
+                    getRegexMatchRanges(text, delim.regex)
+                } catch (e: Exception) {
+                    // If regex is invalid, skip this chunk
+                    emptyList()
+                }
+            }
+        }
+        return when (position) {
+            is OccurrencePosition.All -> ranges
+            is OccurrencePosition.First -> ranges.take(1)
+            is OccurrencePosition.Last -> ranges.takeLast(1)
+            is OccurrencePosition.Nth -> ranges.getOrNull(position.n)?.let { listOf(it) } ?: emptyList()
+            is OccurrencePosition.Indices -> position.indices.mapNotNull { ranges.getOrNull(it) }
+        }
+    }
+
+    /**
      * Gets the ranges of all matches of the given regex in the text.
      */
     fun getRegexMatchRanges(text: String, regex: Regex): List<IntRange> {

--- a/compose/src/test/java/com/mamboa/easyspans/compose/EasySpansComposeTest.kt
+++ b/compose/src/test/java/com/mamboa/easyspans/compose/EasySpansComposeTest.kt
@@ -2,6 +2,7 @@ package com.mamboa.easyspans.compose
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.BaselineShift
@@ -1735,5 +1736,69 @@ class EasySpansComposeTest {
         assertEquals(1, spanStyles.count { it.item.color == Color.Blue && it.start == boundaries1[0].first && it.end == boundaries1[0].last + 1 })
         assertEquals(1, spanStyles.count { it.item.color == Color.Green && it.start == boundaries2[0].first && it.end == boundaries2[0].last + 1 })
         assertEquals(1, spanStyles.count { it.item.color == Color.Red && it.start == boundaries3[0].first && it.end == boundaries3[0].last + 1 })
+    }
+
+    @Test
+    fun `test addSpan with base SpanStyle overrides all other properties`() {
+        val result = EasySpansCompose("Test Text") {
+            setColor(Color.Red)
+            setFontSize(16.sp)
+            setSpanStyle(
+                SpanStyle(
+                    color = Color.Blue,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            )
+        }
+
+        val spanStyle = result.spanStyles[0].item
+        assertEquals(Color.Blue, spanStyle.color)
+        assertEquals(20.sp, spanStyle.fontSize)
+        assertEquals(FontWeight.Bold, spanStyle.fontWeight)
+    }
+
+    @Test
+    fun `test individual properties override SpanStyle properties`() {
+        val result = EasySpansCompose("Test Text") {
+            setSpanStyle(
+                SpanStyle(
+                    color = Color.Blue,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            )
+            setColor(Color.Red) // Should override the blue color from SpanStyle
+        }
+
+        val spanStyle = result.spanStyles[0].item
+        assertEquals(Color.Red, spanStyle.color) // Overridden
+        assertEquals(20.sp, spanStyle.fontSize) // From SpanStyle
+        assertEquals(FontWeight.Bold, spanStyle.fontWeight) // From SpanStyle
+    }
+
+    @Test
+    fun `test multiple SpanStyles merge correctly`() {
+        val result = EasySpansCompose("Test Text") {
+            setSpanStyle(
+                SpanStyle(
+                    color = Color.Blue,
+                    fontSize = 20.sp
+                )
+            )
+            setSpanStyle(
+                SpanStyle(
+                    fontWeight = FontWeight.Bold,
+                    textDecoration = TextDecoration.Underline
+                )
+            )
+            setColor(Color.Red) // Should override all previous colors
+        }
+
+        val spanStyle = result.spanStyles[0].item
+        assertEquals(Color.Red, spanStyle.color)
+        assertEquals(20.sp, spanStyle.fontSize)
+        assertEquals(FontWeight.Bold, spanStyle.fontWeight)
+        assertEquals(TextDecoration.Underline, spanStyle.textDecoration)
     }
 }

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -557,6 +557,50 @@ val spanned = EasySpans.Builder(context, "Lorem ipsum dolor", textView)
 textView.text = spanned
 ```
 
+### 18. Custom span .addSpan{}
+Since we didn't support all the available spans in the library, you can use the `addSpan` method to add any custom span you want. 
+For example, if you want to add a `MaskFilterSpan` with a `BlurMaskFilter`, you can do it like this (code example below).
+Now, keep in mind that if you call `addSpan` with a span that is already supported, (example: ```StrikethroughSpan```), and
+the supported span (example here: ```.isStrikeThrough()```) the one we support will supersede. Another thing is that we blocked
+spans like `ClickableSpan` and `URLSpan` from being added with `addSpan`, since we prefer their implementation in the library.
+On the example below, we will add a `MaskFilterSpan` with a `BlurMaskFilter` to the word "tempus" in the text, yet the rest of the text will be underlined.
+
+```kotlin
+val text = "Praesent tempus nibh ac ante aliquet suscipit. Praesent ex lectus, dapibus non porttitor id, aliquet nec sem."
+val tempus = "tempus"
+val blurMask = BlurMaskFilter(5f, BlurMaskFilter.Blur.NORMAL)
+val spanned =
+  EasySpans.Builder(requireContext(), text, binding.textviewFirst)
+    .addSpan { UnderlineSpan()  }
+    .setOccurrenceChunks(
+      OccurrenceChunk(
+        location = OccurrenceLocation(
+          DelimitationType.REGEX(tempus),
+          OccurrencePosition.All
+        ),
+        builder = OccurrenceChunkBuilder()
+          .setColor(android.R.color.holo_red_dark)
+          .addSpan { StrikethroughSpan() }
+          .addSpan { MaskFilterSpan(blurMask) }
+          .setOnLinkClickListener(
+            object : ClickableLinkSpan.OnLinkClickListener {
+              override fun onLinkClick(view: View) {
+                Snackbar.make(
+                  binding.root,
+                  "$tempus clicked",
+                  Snackbar.LENGTH_SHORT
+                ).show()
+              }
+            }
+          ),
+      )
+    )
+    .build()
+    .create() as Spanned
+
+textView.text = spanned
+```
+
 For issues, feature requests, or contributions, refer to the project repository or contact the maintainers.
 
 ## License

--- a/legacy/src/androidTest/java/com/mamboa/easyspans/legacy/EasySpansTest.kt
+++ b/legacy/src/androidTest/java/com/mamboa/easyspans/legacy/EasySpansTest.kt
@@ -1,6 +1,8 @@
 package com.mamboa.easyspans.legacy
 
 import android.content.Context
+import android.graphics.BlurMaskFilter
+import android.graphics.Color
 import android.graphics.Typeface
 import android.os.Build
 import android.text.SpannableStringBuilder
@@ -8,9 +10,11 @@ import android.text.Spanned
 import android.text.style.AbsoluteSizeSpan
 import android.text.style.BackgroundColorSpan
 import android.text.style.ForegroundColorSpan
+import android.text.style.MaskFilterSpan
 import android.text.style.StrikethroughSpan
 import android.text.style.StyleSpan
 import android.text.style.SubscriptSpan
+import android.text.style.SuperscriptSpan
 import android.text.style.TextAppearanceSpan
 import android.text.style.TypefaceSpan
 import android.text.style.UnderlineSpan
@@ -164,7 +168,7 @@ class EasySpansTest {
     fun testDelimiterSuccess() {
         // apply elements to the third  word delimited by space
         val desiredWord = "dolor"
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.BOUNDARY(" "),
@@ -195,7 +199,7 @@ class EasySpansTest {
         // apply elements to the third  word delimited by space
         // trying to get a word with wrong position after delimiter split
         val desiredWord = "dolor"
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.BOUNDARY(" "),
@@ -227,7 +231,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, text)
 
         val occurrencePosition = 0
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.REGEX(regex),
@@ -267,7 +271,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, text)
 
         val occurrencePosition = 2
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.REGEX(regex),
@@ -308,7 +312,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, text)
 
         val occurrencePositionIndexes = arrayListOf(1, 5, 8)
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.REGEX(regex),
@@ -364,7 +368,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, text)
 
         val occurrencePosition = occurrenceBoundaries.size - 1
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.REGEX(regex),
@@ -402,7 +406,7 @@ class EasySpansTest {
     fun testRegexOccurrencePositionAll() {
         // when no occurrence is specified, all words matching the regex will get the span
         val regex = "nec"
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.REGEX(regex),
@@ -449,7 +453,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, text)
 
         // FIRST
-        val spannedFirst = EasySpans.Builder(context, text, TextView(context))
+        val spannedFirst = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.REGEX(regex),
@@ -540,7 +544,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getDelimiterSlicedOccurrencesBoundaries(delimiter, text)
 
         val desiredPosition = 0
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.BOUNDARY(delimiter),
@@ -587,7 +591,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getDelimiterSlicedOccurrencesBoundaries(delimiter, text)
 
         val nthPosition = 5
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.BOUNDARY(delimiter),
@@ -638,7 +642,7 @@ class EasySpansTest {
         val delimiter = "nec"
         val occurrenceBoundaries = getDelimiterSlicedOccurrencesBoundaries(delimiter, text)
 
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.BOUNDARY(delimiter),
@@ -716,7 +720,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getDelimiterSlicedOccurrencesBoundaries(delimiter, text)
 
         val lastPosition = occurrenceBoundaries.size - 1
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.BOUNDARY(delimiter),
@@ -759,7 +763,7 @@ class EasySpansTest {
         val delimiter = " "
         val occurrenceBoundaries = getDelimiterSlicedOccurrencesBoundaries(delimiter, text)
 
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.BOUNDARY(delimiter),
@@ -790,7 +794,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, text)
 
         val occurrencePosition = occurrenceBoundaries.size - 1
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text, textView)
             .isUnderlined()
             .setColor(R.color.teal_700)
             .setOccurrenceChunks(
@@ -801,9 +805,7 @@ class EasySpansTest {
                     ),
                     builder = OccurrenceChunkBuilder()
                         .setOnLinkClickListener(object : ClickableLinkSpan.OnLinkClickListener {
-                            override fun onLinkClick(view: View) {
-                                // get the click listener
-                            }
+                            override fun onLinkClick(view: View) {/* get the click listener */ }
                         })
                 )
             )
@@ -861,9 +863,7 @@ class EasySpansTest {
                         .setColor(R.color.teal_700)
                         .setOnLinkClickListener(
                             object : ClickableLinkSpan.OnLinkClickListener {
-                                override fun onLinkClick(view: View) {
-                                    // get the click listener
-                                }
+                                override fun onLinkClick(view: View) {/* get the click listener */ }
                             }
                         )
                 )
@@ -922,7 +922,7 @@ class EasySpansTest {
         val occurrencesBoundaries =
             ArrayList(occurrenceBoundaries1).apply { addAll(occurrenceBoundaries2) }
 
-        val spanned = EasySpans.Builder(context, text, TextView(context))
+        val spanned = EasySpans.Builder(context, text, textView)
             .setOccurrenceChunks(
                 OccurrenceChunk(
                     location = OccurrenceLocation(
@@ -930,9 +930,7 @@ class EasySpansTest {
                     ),
                     builder = OccurrenceChunkBuilder()
                         .setOnLinkClickListener(object : ClickableLinkSpan.OnLinkClickListener {
-                            override fun onLinkClick(view: View) {
-                                // get the click listener
-                            }
+                            override fun onLinkClick(view: View) {/* no-op */ }
                         })
                 ),
 
@@ -942,9 +940,7 @@ class EasySpansTest {
                     ),
                     builder = OccurrenceChunkBuilder()
                         .setOnLinkClickListener(object : ClickableLinkSpan.OnLinkClickListener {
-                            override fun onLinkClick(view: View) {
-                                // get the click listener
-                            }
+                            override fun onLinkClick(view: View) { /* no-op */ }
                         })
                 )
             )
@@ -992,7 +988,7 @@ class EasySpansTest {
         val typeFace = Typeface.ITALIC
         val colorRes = R.color.purple_500
 
-        val spanned = EasySpans.Builder(context, text, textView)
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceLocation(
                 OccurrenceLocation(
                     DelimitationType.REGEX(regex),
@@ -1052,8 +1048,7 @@ class EasySpansTest {
                         .isUnderlined() // Override default link underline
                         .setOnLinkClickListener(
                             object : ClickableLinkSpan.OnLinkClickListener {
-                                override fun onLinkClick(view: View) { /* no-op */
-                                }
+                                override fun onLinkClick(view: View) { /* no-op */ }
                             }
                         )
                 )
@@ -1175,8 +1170,7 @@ class EasySpansTest {
                     builder = OccurrenceChunkBuilder()
                         .setOnLinkClickListener(
                             object : ClickableLinkSpan.OnLinkClickListener {
-                                override fun onLinkClick(view: View) { /* no-op */
-                                }
+                                override fun onLinkClick(view: View) { /* no-op */ }
                             }
                         )
                 )
@@ -1218,8 +1212,7 @@ class EasySpansTest {
                     builder = OccurrenceChunkBuilder()
                         .setOnLinkClickListener(
                             object : ClickableLinkSpan.OnLinkClickListener {
-                                override fun onLinkClick(view: View) { /* no-op */
-                                }
+                                override fun onLinkClick(view: View) { /* no-op */ }
                             }
                         )
                 )
@@ -1254,8 +1247,7 @@ class EasySpansTest {
                     builder = OccurrenceChunkBuilder()
                         .setOnLinkClickListener(
                             object : ClickableLinkSpan.OnLinkClickListener {
-                                override fun onLinkClick(view: View) { /* no-op */
-                                }
+                                override fun onLinkClick(view: View) { /* no-op */ }
                             }
                         )
                 )
@@ -1321,8 +1313,7 @@ class EasySpansTest {
                         .setColor(R.color.purple_500)
                         .setOnLinkClickListener(
                             object : ClickableLinkSpan.OnLinkClickListener {
-                                override fun onLinkClick(view: View) { /* no-op */
-                                }
+                                override fun onLinkClick(view: View) { /* no-op */ }
                             }
                         )
                 ),
@@ -1458,8 +1449,7 @@ class EasySpansTest {
                     builder = OccurrenceChunkBuilder()
                         .setOnLinkClickListener(
                             object : ClickableLinkSpan.OnLinkClickListener {
-                                override fun onLinkClick(view: View) { /* no-op */
-                                }
+                                override fun onLinkClick(view: View) { /* no-op */ }
                             }
                         )
                 )
@@ -1491,8 +1481,7 @@ class EasySpansTest {
                 builder = OccurrenceChunkBuilder().setColor(R.color.teal_200)
                     .setOnLinkClickListener(
                         object : ClickableLinkSpan.OnLinkClickListener {
-                            override fun onLinkClick(view: View) { /* no-op */
-                            }
+                            override fun onLinkClick(view: View) { /* no-op */ }
                         }
                     )
             )
@@ -2144,23 +2133,26 @@ class EasySpansTest {
         }
     }
 
-    /*@Test
+    @Test
     fun testNullTextViewReference() {
         val regex = "dolor"
         val testText = "Lorem ipsum dolor"
 
         try {
-            val spanned = EasySpans.Builder(context, testText, null)
+            val spanned = EasySpans.Builder(context, testText)
                 .setOccurrenceChunks(
                     OccurrenceChunk(
                         location = OccurrenceLocation(
                             delimitationType = DelimitationType.REGEX(regex),
                             occurrencePosition = OccurrencePosition.First
                         ),
-                        onLinkClickListener = object : ClickableLinkSpan.OnLinkClickListener {
-                            override fun onLinkClick(view: View) { *//* no-op *//* }
-                        },
-                        targetTextView = null
+                        builder = OccurrenceChunkBuilder()
+                            .setColor(R.color.teal_700)
+                            .setOnLinkClickListener(
+                                object : ClickableLinkSpan.OnLinkClickListener {
+                                    override fun onLinkClick(view: View) { /* no-op */ }
+                                }
+                            )
                     )
                 )
                 .build()
@@ -2176,7 +2168,7 @@ class EasySpansTest {
             // Expected if EasySpans enforces non-null TextView
             Assert.assertTrue(true)
         }
-    }*/
+    }
 
     @Test
     fun testInvalidSpanConfigurations() {
@@ -2447,7 +2439,7 @@ class EasySpansTest {
         val initialEnabled = textView.isEnabled
 
         // Re-apply spans
-        val newSpanned = EasySpans.Builder(context, testText, textView)
+        val newSpanned = EasySpans.Builder(context, testText)
             .setOccurrenceChunks(
                 OccurrenceChunk(
                     location = OccurrenceLocation(
@@ -2474,7 +2466,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex1, text)
         Assert.assertTrue(occurrenceBoundaries.isNotEmpty())
 
-        val spanned = EasySpans.Builder(context, text, textView)
+        val spanned = EasySpans.Builder(context, text)
             .setOccurrenceChunks(
                 OccurrenceChunk(
                     location = OccurrenceLocation(
@@ -2520,7 +2512,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, testText)
         Assert.assertTrue(occurrenceBoundaries.isNotEmpty())
 
-        val spanned1 = EasySpans.Builder(context, testText, textView)
+        val spanned1 = EasySpans.Builder(context, testText)
             .setOccurrenceChunks(
                 OccurrenceChunk(
                     location = OccurrenceLocation(
@@ -2534,7 +2526,7 @@ class EasySpansTest {
             .create() as Spanned
 
         // Apply different span
-        val spanned2 = EasySpans.Builder(context, testText, textView)
+        val spanned2 = EasySpans.Builder(context, testText)
             .setOccurrenceChunks(
                 OccurrenceChunk(
                     location = OccurrenceLocation(
@@ -2568,7 +2560,7 @@ class EasySpansTest {
         val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, testText)
         Assert.assertTrue(occurrenceBoundaries.isNotEmpty())
 
-        val spanned = EasySpans.Builder(context, testText, textView)
+        val spanned = EasySpans.Builder(context, testText)
             .setOccurrenceChunks(
                 OccurrenceChunk(
                     location = OccurrenceLocation(
@@ -2600,10 +2592,164 @@ class EasySpansTest {
         Assert.assertEquals(testText, spanned.toString())
     }
 
+    @Test
+    fun testAddSpanWithSingleCustomSpan() {
+        val testText = "Hello World"
+        val regex = "World"
+        val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, testText)
+        Assert.assertTrue(occurrenceBoundaries.isNotEmpty())
+
+        val spanned = EasySpans.Builder(context, testText)
+            .setOccurrenceChunks(
+                OccurrenceChunk(
+                    location = OccurrenceLocation(
+                        delimitationType = DelimitationType.REGEX(regex),
+                        occurrencePosition = OccurrencePosition.First
+                    ),
+                    builder = OccurrenceChunkBuilder()
+                        .addSpan { StrikethroughSpan() }
+                )
+            )
+            .build()
+            .create() as SpannableStringBuilder
+
+        val strikeSpans = spanned.getSpans(
+            occurrenceBoundaries[0].first,
+            occurrenceBoundaries[0].last + 1,
+            StrikethroughSpan::class.java
+        )
+        Assert.assertEquals(1, strikeSpans.size)
+    }
+
+    @Test
+    fun testAddSpanWithMultipleCustomSpans() {
+        val testText = "Test Text"
+        val regex = "Text"
+        val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, testText)
+        Assert.assertTrue(occurrenceBoundaries.isNotEmpty())
+
+        val spanned = EasySpans.Builder(context, testText)
+            .setOccurrenceChunks(
+                OccurrenceChunk(
+                    location = OccurrenceLocation(
+                        delimitationType = DelimitationType.REGEX(regex),
+                        occurrencePosition = OccurrencePosition.First
+                    ),
+                    builder = OccurrenceChunkBuilder()
+                        .addSpan { StrikethroughSpan() }
+                        .addSpan { SuperscriptSpan() }
+                        .addSpan { StyleSpan(Typeface.BOLD) }
+                )
+            )
+            .build()
+            .create() as SpannableStringBuilder
+
+        val start = occurrenceBoundaries[0].first
+        val end = occurrenceBoundaries[0].last + 1
+
+        Assert.assertEquals(1, spanned.getSpans(start, end, StrikethroughSpan::class.java).size)
+        Assert.assertEquals(1, spanned.getSpans(start, end, SuperscriptSpan::class.java).size)
+        Assert.assertEquals(1, spanned.getSpans(start, end, StyleSpan::class.java).size)
+    }
+
+    @Test
+    fun testAddSpanWithSpanRemoval() {
+        val testText = "Sample Text"
+        val regex = "Sample"
+        val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, testText)
+        Assert.assertTrue(occurrenceBoundaries.isNotEmpty())
+
+        val spanned = EasySpans.Builder(context, testText)
+            .setOccurrenceChunks(
+                OccurrenceChunk(
+                    location = OccurrenceLocation(
+                        delimitationType = DelimitationType.REGEX(regex),
+                        occurrencePosition = OccurrencePosition.First
+                    ),
+                    builder = OccurrenceChunkBuilder()
+                        .setColor(R.color.teal_700)
+                        .addSpan { StrikethroughSpan() }
+                )
+            )
+            .build()
+            .create() as SpannableStringBuilder
+
+        val start = occurrenceBoundaries[0].first
+        val end = occurrenceBoundaries[0].last + 1
+
+        val strikeSpan = spanned.getSpans(start, end, StrikethroughSpan::class.java)[0]
+        spanned.removeSpan(strikeSpan)
+
+        Assert.assertEquals(0, spanned.getSpans(start, end, StrikethroughSpan::class.java).size)
+        Assert.assertEquals(1, spanned.getSpans(start, end, ForegroundColorSpan::class.java).size)
+    }
+
+    @Test
+    fun testCustomSpanWithBlurMask() {
+        val testText = "Lorem ipsum dolor"
+        val regex = "ipsum"
+        val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, testText)
+        Assert.assertTrue(occurrenceBoundaries.isNotEmpty())
+
+        val blurMask = BlurMaskFilter(5f, BlurMaskFilter.Blur.NORMAL)
+        val spanned = EasySpans.Builder(context, testText)
+            .setOccurrenceChunks(
+                OccurrenceChunk(
+                    location = OccurrenceLocation(
+                        delimitationType = DelimitationType.REGEX(regex),
+                        occurrencePosition = OccurrencePosition.First
+                    ),
+                    builder = OccurrenceChunkBuilder()
+                        .addSpan { MaskFilterSpan(blurMask) }
+                )
+            )
+            .build()
+            .create() as SpannableStringBuilder
+
+        val maskSpans = spanned.getSpans(
+            occurrenceBoundaries[0].first,
+            occurrenceBoundaries[0].last + 1,
+            MaskFilterSpan::class.java
+        )
+        Assert.assertEquals(1, maskSpans.size)
+
+        // Note: Visual verification required for blur effect
+        Assert.assertEquals(testText, spanned.toString())
+    }
+
+    @Test
+    fun testCustomSpanWithMultipleEffects() {
+        val testText = "Sample Text"
+        val regex = "Text"
+        val occurrenceBoundaries = getRegexOccurrencesBoundaries(regex, testText)
+        Assert.assertTrue(occurrenceBoundaries.isNotEmpty())
+
+        val spanned = EasySpans.Builder(context, testText)
+            .setOccurrenceChunks(
+                OccurrenceChunk(
+                    location = OccurrenceLocation(
+                        delimitationType = DelimitationType.REGEX(regex),
+                        occurrencePosition = OccurrencePosition.First
+                    ),
+                    builder = OccurrenceChunkBuilder()
+                        .addSpan { StrikethroughSpan() }
+                        .addSpan { SuperscriptSpan() }
+                        .addSpan { ForegroundColorSpan(Color.RED) }
+                )
+            )
+            .build()
+            .create() as SpannableStringBuilder
+
+        val start = occurrenceBoundaries[0].first
+        val end = occurrenceBoundaries[0].last + 1
+
+        Assert.assertEquals(1, spanned.getSpans(start, end, StrikethroughSpan::class.java).size)
+        Assert.assertEquals(1, spanned.getSpans(start, end, SuperscriptSpan::class.java).size)
+        Assert.assertEquals(1, spanned.getSpans(start, end, ForegroundColorSpan::class.java).size)
+    }
 
     @After
-    fun teardown() {
-    }
+    fun teardown() {}
 
     private fun getRegexOccurrencesBoundaries(regex: String, text: String): List<IntRange> {
         return Regex(regex).findAll(text).map { it.range }.toList()

--- a/legacy/src/main/java/com/mamboa/easyspans/legacy/customspans/ClickableLinkSpan.kt
+++ b/legacy/src/main/java/com/mamboa/easyspans/legacy/customspans/ClickableLinkSpan.kt
@@ -6,8 +6,8 @@ import android.view.View
 import androidx.annotation.ColorInt
 
 class ClickableLinkSpan (@ColorInt private val linkColor: Int,
-                         private val isLinkUnderLine: Boolean = true,
-                         private val onLinkClickedListener: OnLinkClickListener?) : ClickableSpan() {
+                              private val isLinkUnderLine: Boolean = true,
+                              private val onLinkClickedListener: OnLinkClickListener?) : ClickableSpan() {
 
     override fun updateDrawState(ds: TextPaint) {
         super.updateDrawState(ds)

--- a/legacy/src/main/java/com/mamboa/easyspans/legacy/customspans/ClickableLinkSpan.kt
+++ b/legacy/src/main/java/com/mamboa/easyspans/legacy/customspans/ClickableLinkSpan.kt
@@ -5,9 +5,20 @@ import android.text.style.ClickableSpan
 import android.view.View
 import androidx.annotation.ColorInt
 
-class ClickableLinkSpan (@ColorInt private val linkColor: Int,
-                              private val isLinkUnderLine: Boolean = true,
-                              private val onLinkClickedListener: OnLinkClickListener?) : ClickableSpan() {
+/**
+ * A custom ClickableSpan that allows for clickable links with customizable color and underline options.
+ * This span can be used to create clickable links in a TextView, with the ability to specify
+ * the link color and whether the link should be underlined.
+ *
+ * @param linkColor The color of the link text.
+ * @param isLinkUnderLine Whether the link text should be underlined.
+ * @param onLinkClickedListener Optional listener for link click events.
+ */
+class ClickableLinkSpan(
+    @ColorInt internal val linkColor: Int,
+    internal val isLinkUnderLine: Boolean = true,
+    internal val onLinkClickedListener: OnLinkClickListener?
+) : ClickableSpan() {
 
     override fun updateDrawState(ds: TextPaint) {
         super.updateDrawState(ds)

--- a/legacy/src/main/java/com/mamboa/easyspans/legacy/customspans/PaddingBackgroundColorSpan.kt
+++ b/legacy/src/main/java/com/mamboa/easyspans/legacy/customspans/PaddingBackgroundColorSpan.kt
@@ -3,12 +3,11 @@ package com.mamboa.easyspans.legacy.customspans
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Rect
-import android.text.TextUtils
 import android.text.style.LineBackgroundSpan
 import android.view.Gravity
 import android.view.View
-import java.util.*
 import androidx.core.text.layoutDirection
+import java.util.Locale
 
 /*
  * When trying to put a background color on the text only within textview, there is no padding. This
@@ -20,34 +19,73 @@ import androidx.core.text.layoutDirection
  * A custom LineBackgroundSpan that allows adding a background color with padding around the text.
  * This span can be used to create a visually appealing background for text in a TextView,
  * with the ability to specify padding and gravity.
- * @param mBackgroundColor The color of the background.
- * @param mPadding The padding to be applied around the text.
+ * @param backgroundColor The color of the background.
+ * @param padding The padding to be applied around the text.
  * @param gravity The gravity of the text, which determines how the background is aligned relative to the text.
  */
-class PaddingBackgroundColorSpan(private val mBackgroundColor: Int, private val mPadding: Int, private val gravity: Int) :
+class PaddingBackgroundColorSpan(
+    internal val backgroundColor: Int,
+    internal val padding: Int,
+    internal val gravity: Int
+) :
     LineBackgroundSpan {
     private val backgroundRect = Rect()
 
-    override fun drawBackground(c: Canvas, p: Paint, left: Int, right: Int, top: Int, baseline: Int, bottom: Int, text: CharSequence, start: Int, end: Int, lnum: Int) {
-        val textWidth = Math.round(p.measureText(text, start, end))
-        val paintColor = p.color
+    override fun drawBackground(
+        canvas: Canvas,
+        paint: Paint,
+        left: Int,
+        right: Int,
+        top: Int,
+        baseline: Int,
+        bottom: Int,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        lineNumber: Int
+    ) {
+        val textWidth = Math.round(paint.measureText(text, start, end))
+        val paintColor = paint.color
 
-        val finalTop = top - if (lnum == 0) mPadding / 2 else -(mPadding / 2)
-        val finalBottom = bottom + mPadding / 2
+        val finalTop = top - if (lineNumber == 0) padding / 2 else -(padding / 2)
+        val finalBottom = bottom + padding / 2
         val isLeftToRight = Locale.getDefault().layoutDirection == View.LAYOUT_DIRECTION_LTR
         // Draw the background
-        backgroundRect.set(when {
-            gravity == Gravity.LEFT || (isLeftToRight &&  gravity == Gravity.START) || (!isLeftToRight &&  gravity == Gravity.END) -> getLeftRect(left, finalTop, right, finalBottom, textWidth)
-            gravity == Gravity.CENTER -> getCenterRect(left, finalTop, right, finalBottom, textWidth)
-            gravity == Gravity.RIGHT || (isLeftToRight &&  gravity == Gravity.END) || (!isLeftToRight &&  gravity == Gravity.START) -> getRightRect(left, finalTop, right, finalBottom, textWidth)
-            else -> {
-                getLeftRect(left, finalTop, right, finalBottom, textWidth)
-            }
-        })
+        backgroundRect.set(
+            when {
+                gravity == Gravity.LEFT || (isLeftToRight && gravity == Gravity.START) || (!isLeftToRight && gravity == Gravity.END) -> getLeftRect(
+                    left,
+                    finalTop,
+                    right,
+                    finalBottom,
+                    textWidth
+                )
 
-        p.color = mBackgroundColor
-        c.drawRect(backgroundRect, p)
-        p.color = paintColor
+                gravity == Gravity.CENTER -> getCenterRect(
+                    left,
+                    finalTop,
+                    right,
+                    finalBottom,
+                    textWidth
+                )
+
+                gravity == Gravity.RIGHT || (isLeftToRight && gravity == Gravity.END) || (!isLeftToRight && gravity == Gravity.START) -> getRightRect(
+                    left,
+                    finalTop,
+                    right,
+                    finalBottom,
+                    textWidth
+                )
+
+                else -> {
+                    getLeftRect(left, finalTop, right, finalBottom, textWidth)
+                }
+            }
+        )
+
+        paint.color = backgroundColor
+        canvas.drawRect(backgroundRect, paint)
+        paint.color = paintColor
     }
 
     /**
@@ -62,7 +100,7 @@ class PaddingBackgroundColorSpan(private val mBackgroundColor: Int, private val 
      * @return Rect - containing the coordinates to draw the background
      */
     private fun getLeftRect(left: Int, top: Int, right: Int, bottom: Int, textWidth: Int): Rect {
-        return Rect(left - mPadding, top, left + textWidth + mPadding, bottom)
+        return Rect(left - padding, top, left + textWidth + padding, bottom)
     }
 
     /**
@@ -77,7 +115,7 @@ class PaddingBackgroundColorSpan(private val mBackgroundColor: Int, private val 
      * @return Rect - containing the coordinates to draw the background
      */
     private fun getRightRect(left: Int, top: Int, right: Int, bottom: Int, textWidth: Int): Rect {
-        return Rect(right - textWidth - mPadding, top, right + mPadding, bottom)
+        return Rect(right - textWidth - padding, top, right + padding, bottom)
     }
 
     /**
@@ -93,6 +131,6 @@ class PaddingBackgroundColorSpan(private val mBackgroundColor: Int, private val 
      */
     private fun getCenterRect(left: Int, top: Int, right: Int, bottom: Int, textWidth: Int): Rect {
         val diff = kotlin.math.abs((right - left) / 2 - textWidth / 2)
-        return Rect(left + diff - mPadding, top, right - diff + mPadding, bottom)
+        return Rect(left + diff - padding, top, right - diff + padding, bottom)
     }
 }

--- a/legacy/src/main/java/com/mamboa/easyspans/legacy/customspans/PaddingBackgroundColorSpan.kt
+++ b/legacy/src/main/java/com/mamboa/easyspans/legacy/customspans/PaddingBackgroundColorSpan.kt
@@ -8,6 +8,7 @@ import android.text.style.LineBackgroundSpan
 import android.view.Gravity
 import android.view.View
 import java.util.*
+import androidx.core.text.layoutDirection
 
 /*
  * When trying to put a background color on the text only within textview, there is no padding. This
@@ -33,7 +34,7 @@ class PaddingBackgroundColorSpan(private val mBackgroundColor: Int, private val 
 
         val finalTop = top - if (lnum == 0) mPadding / 2 else -(mPadding / 2)
         val finalBottom = bottom + mPadding / 2
-        val isLeftToRight = TextUtils.getLayoutDirectionFromLocale(Locale.getDefault()) == View.LAYOUT_DIRECTION_LTR
+        val isLeftToRight = Locale.getDefault().layoutDirection == View.LAYOUT_DIRECTION_LTR
         // Draw the background
         backgroundRect.set(when {
             gravity == Gravity.LEFT || (isLeftToRight &&  gravity == Gravity.START) || (!isLeftToRight &&  gravity == Gravity.END) -> getLeftRect(left, finalTop, right, finalBottom, textWidth)

--- a/legacy/src/main/java/com/mamboa/easyspans/legacy/helper/OccurrenceChunk.kt
+++ b/legacy/src/main/java/com/mamboa/easyspans/legacy/helper/OccurrenceChunk.kt
@@ -13,11 +13,16 @@ import com.mamboa.easyspans.legacy.EasySpans
 import com.mamboa.easyspans.legacy.customspans.ClickableLinkSpan
 import com.mamboa.easyspans.legacy.customspans.TextCaseSpan
 import com.mamboa.easyspans.legacy.styling.SpanFactory
+import java.util.Collections
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Represents a rich occurrence styling chunk, with configuration for spans and link handling.
  * Requires targetTextView at construction, ensuring no lateinit or null issues.
+ *
+ * @property location The location of the occurrence in the text.
+ * @property builder Optional builder for configuring styles and spans.
  */
 class OccurrenceChunk(
     val location: OccurrenceLocation,
@@ -30,11 +35,14 @@ class OccurrenceChunk(
     }
 
     // Encapsulate mutability, expose as read-only views
-    private val _characterStyleSpans = hashMapOf<String, (Any) -> CharacterStyle>()
-    val characterStyleSpans: Map<String, (Any) -> CharacterStyle> get() = _characterStyleSpans
+    private val _characterStyleSpans = ConcurrentHashMap<String, (Any) -> CharacterStyle>()
+    val characterStyleSpans: Map<String, (Any) -> CharacterStyle>
+        get() = Collections.unmodifiableMap(_characterStyleSpans)
 
-    private val _paragraphStyleSpans = hashMapOf<String, (Any) -> ParagraphStyle?>()
-    val paragraphStyleSpans: Map<String, (Any) -> ParagraphStyle?> get() = _paragraphStyleSpans
+    private val _paragraphStyleSpans = ConcurrentHashMap<String, (Any) -> ParagraphStyle?>()
+    val paragraphStyleSpans: Map<String, (Any) -> ParagraphStyle?>
+        get() = Collections.unmodifiableMap(_paragraphStyleSpans)
+
 
     fun getOccurrenceType(key: String): OccurrenceType {
         return if (builder == null)

--- a/legacy/src/main/java/com/mamboa/easyspans/legacy/helper/OccurrenceChunk.kt
+++ b/legacy/src/main/java/com/mamboa/easyspans/legacy/helper/OccurrenceChunk.kt
@@ -3,11 +3,14 @@ package com.mamboa.easyspans.legacy.helper
 import android.content.Context
 import android.os.Build
 import android.text.style.CharacterStyle
+import android.text.style.ClickableSpan
 import android.text.style.ParagraphStyle
 import android.text.style.SubscriptSpan
 import android.text.style.SuperscriptSpan
+import android.text.style.URLSpan
 import android.widget.TextView
 import com.mamboa.easyspans.legacy.EasySpans
+import com.mamboa.easyspans.legacy.customspans.ClickableLinkSpan
 import com.mamboa.easyspans.legacy.customspans.TextCaseSpan
 import com.mamboa.easyspans.legacy.styling.SpanFactory
 import java.util.UUID
@@ -140,7 +143,7 @@ class OccurrenceChunk(
             }
 
             // Only remove conflicting color if ClickableLinkSpan uses its own color
-            if (_characterStyleSpans.containsKey(EasySpans.Config.CLICKABLE_LINK_TAG) && color == EasySpans.Config.ID_NULL) {
+            if (_characterStyleSpans.containsKey(EasySpans.Config.CLICKABLE_LINK_TAG) && color != EasySpans.Config.ID_NULL) {
                 _characterStyleSpans.remove(EasySpans.Config.COLOR_TAG)
             }
             // Always remove underline if ClickableLinkSpan is applied to avoid duplication
@@ -150,6 +153,14 @@ class OccurrenceChunk(
 
             // add all custom character styles to the map if any
             customCharacterStyles?.forEach { value ->
+                val sampleSpan = try {
+                    value(Any())
+                } catch (e: Exception) {
+                    throw IllegalArgumentException("Invalid custom character style: ${e.message}")
+                }
+                if (sampleSpan is ClickableLinkSpan || sampleSpan is ClickableSpan || sampleSpan is URLSpan) {
+                    throw IllegalArgumentException("Custom character styles cannot include ClickableLinkSpan or URLSpan. Use OccurrenceChunkBuilder.setOnLinkClickListener for clickable behavior.")
+                }
                  val key = UUID.randomUUID().toString()
                 _characterStyleSpans[key] = value
             }

--- a/legacy/src/main/java/com/mamboa/easyspans/legacy/helper/OccurrenceChunkBuilder.kt
+++ b/legacy/src/main/java/com/mamboa/easyspans/legacy/helper/OccurrenceChunkBuilder.kt
@@ -203,9 +203,9 @@ class OccurrenceChunkBuilder {
     }
 
     fun addSpan(span: (Any) -> Any) = apply {
-        when (val result = span(Any())) {
-            is CharacterStyle -> addACharacterSpan { _ -> result as CharacterStyle }
-            is ParagraphStyle -> addAParagraphSpan { _ -> result as ParagraphStyle }
+        when (span(Any())) {
+            is CharacterStyle -> addACharacterSpan(span as (Any) -> CharacterStyle)
+            is ParagraphStyle -> addAParagraphSpan(span as (Any) -> ParagraphStyle)
             else -> throw IllegalArgumentException("Span must produce a CharacterStyle or ParagraphStyle")
         }
     }

--- a/legacy/src/main/java/com/mamboa/easyspans/legacy/helper/OccurrenceChunkBuilder.kt
+++ b/legacy/src/main/java/com/mamboa/easyspans/legacy/helper/OccurrenceChunkBuilder.kt
@@ -1,5 +1,7 @@
 package com.mamboa.easyspans.legacy.helper
 
+import android.text.style.CharacterStyle
+import android.text.style.ParagraphStyle
 import android.widget.TextView
 import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
@@ -8,6 +10,7 @@ import androidx.annotation.StyleRes
 import com.mamboa.easyspans.legacy.EasySpans
 import com.mamboa.easyspans.legacy.customspans.ClickableLinkSpan
 import com.mamboa.easyspans.legacy.customspans.TextCaseSpan
+import java.util.ArrayList
 
 /**
  * Collects per-chunk style configuration for use with OccurrenceChunk.
@@ -15,6 +18,7 @@ import com.mamboa.easyspans.legacy.customspans.TextCaseSpan
  * Intended for one-time use/configuration before passing to OccurrenceChunk.
  */
 class OccurrenceChunkBuilder {
+
     /** Color to apply to this chunk */
     @ColorRes
     var color: Int = EasySpans.Config.ID_NULL
@@ -69,6 +73,12 @@ class OccurrenceChunkBuilder {
     /** Target TextView for clickable links or paragraph background */
     var targetTextView: TextView? = null
         private set
+
+    /** Custom character styles to apply to this chunk */
+    var customCharacterStyles: ArrayList<(Any) -> CharacterStyle>? = null
+
+    /** Custom paragraph styles to apply to this chunk */
+    var customParagraphStyles: ArrayList<(Any) -> ParagraphStyle>? = null
 
     /**
      * Sets the color to apply to this chunk.
@@ -166,5 +176,37 @@ class OccurrenceChunkBuilder {
      */
     fun setTargetTextView(textView: TextView?) = apply {
         targetTextView = textView
+    }
+
+    /**
+     * Adds a custom character style to this chunk.
+     * @param style the character style to add
+     * @return this OccurrenceChunkBuilder instance
+     */
+    private fun addACharacterSpan(style: (Any) -> CharacterStyle) = apply {
+        if (customCharacterStyles == null) {
+            customCharacterStyles = ArrayList()
+        }
+        customCharacterStyles?.add(style)
+    }
+
+    /**
+     * Adds a custom paragraph style to this chunk.
+     * @param style the paragraph style to add
+     * @return this OccurrenceChunkBuilder instance
+     */
+    private fun addAParagraphSpan(style: (Any) -> ParagraphStyle) = apply {
+        if (customParagraphStyles == null) {
+            customParagraphStyles = ArrayList()
+        }
+        customParagraphStyles?.add(style)
+    }
+
+    fun addSpan(span: (Any) -> Any) = apply {
+        when (val result = span(Any())) {
+            is CharacterStyle -> addACharacterSpan { _ -> result as CharacterStyle }
+            is ParagraphStyle -> addAParagraphSpan { _ -> result as ParagraphStyle }
+            else -> throw IllegalArgumentException("Span must produce a CharacterStyle or ParagraphStyle")
+        }
     }
 }

--- a/legacy/src/main/java/com/mamboa/easyspans/legacy/styling/SpanFactory.kt
+++ b/legacy/src/main/java/com/mamboa/easyspans/legacy/styling/SpanFactory.kt
@@ -253,6 +253,13 @@ class SpanFactory(private val context: Context) {
     companion object {
         private const val ID_NULL = 0
 
+        /**
+         * Applies a text case transformation to a section of the SpannableStringBuilder.
+         * This is used internally to handle text case spans.
+         * @param start The start index of the text section to transform.
+         * @param end The end index of the text section to transform.
+         * @param textCaseType The type of text case transformation to apply.
+         */
         private fun SpannableStringBuilder.applyTextCaseOnTextSection(
             start: Int,
             end: Int,
@@ -269,6 +276,14 @@ class SpanFactory(private val context: Context) {
             this.replace(start, end, chunk)
         }
 
+        /**
+         * Sets a custom span on a section of the SpannableStringBuilder.
+         * This is used internally to handle various spans, including text case spans.
+         * @param tag The tag associated with the span.
+         * @param span The CharacterStyle span to apply.
+         * @param startIndex The start index of the text section to apply the span.
+         * @param endIndex The end index of the text section to apply the span.
+         */
         fun SpannableStringBuilder.setCustomSpan(
             tag: String,
             span: CharacterStyle,

--- a/legacy/src/main/java/com/mamboa/easyspans/legacy/styling/SpanFactory.kt
+++ b/legacy/src/main/java/com/mamboa/easyspans/legacy/styling/SpanFactory.kt
@@ -174,8 +174,11 @@ class SpanFactory(private val context: Context) {
      */
     fun createBackgroundParagraphStyle(
         sequenceBackgroundColor: SequenceBackgroundColor,
-        targetTextView: TextView
+        targetTextView: TextView?
     ): ParagraphStyle {
+        if (targetTextView == null) {
+            throw NullPointerException("targetTextView must be provided when paragraphBackgroundColor is set")
+        }
         val colorValue = ContextCompat.getColor(context, sequenceBackgroundColor.backgroundColor)
         @DimenRes val paddingID =
             if (sequenceBackgroundColor.padding != ID_NULL) sequenceBackgroundColor.padding else R.dimen.test_no_dp
@@ -250,7 +253,7 @@ class SpanFactory(private val context: Context) {
     companion object {
         private const val ID_NULL = 0
 
-        fun SpannableStringBuilder.applyTextCaseOnTextSection(
+        private fun SpannableStringBuilder.applyTextCaseOnTextSection(
             start: Int,
             end: Int,
             textCaseType: TextCaseSpan.TextCaseType = TextCaseSpan.TextCaseType.NORMAL
@@ -272,7 +275,7 @@ class SpanFactory(private val context: Context) {
             startIndex: Int,
             endIndex: Int,
         )  {
-            if (tag == EasySpans.Config.TEXT_CASE_TYPE_TAG) {
+            if (tag == EasySpans.Config.TEXT_CASE_TYPE_TAG || span is TextCaseSpan) {
                 this.applyTextCaseOnTextSection(
                     startIndex,
                     endIndex,

--- a/legacy/src/main/java/com/mamboa/easyspans/legacy/styling/StyleApplier.kt
+++ b/legacy/src/main/java/com/mamboa/easyspans/legacy/styling/StyleApplier.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import android.widget.TextView
 import com.mamboa.easyspans.legacy.EasySpans
 import com.mamboa.easyspans.legacy.customspans.ClickableLinkSpan
+import com.mamboa.easyspans.legacy.customspans.PaddingBackgroundColorSpan
 import com.mamboa.easyspans.legacy.customspans.TextCaseSpan
 import com.mamboa.easyspans.legacy.helper.DelimitationType
 import com.mamboa.easyspans.legacy.helper.OccurrenceChunk
@@ -133,13 +134,21 @@ class StyleApplier(
             } catch (e: Exception) {
                 throw IllegalArgumentException("Invalid custom character style: ${e.message}")
             }
-            if (sampleSpan is ClickableLinkSpan || sampleSpan is ClickableSpan || sampleSpan is URLSpan) {
+            if (sampleSpan is ClickableLinkSpan || sampleSpan is ClickableSpan) {
                 throw IllegalArgumentException("Custom character styles cannot include ClickableLinkSpan or URLSpan. Use OccurrenceChunkBuilder.setOnLinkClickListener for clickable behavior.")
             }
             val key = UUID.randomUUID().toString()
             mapOfCharacterStyleSpans[key] = value
         }
         config.customParagraphStyles?.forEach { value ->
+            val sampleSpan = try {
+                value(Any())
+            } catch (e: Exception) {
+                throw IllegalArgumentException("Invalid custom paragraph style: ${e.message}")
+            }
+            if (sampleSpan is PaddingBackgroundColorSpan && targetTextView == null) {
+                throw NullPointerException("targetTextView must be provided when using PaddingBackgroundColorSpan in custom paragraph styles.")
+            }
             val key = UUID.randomUUID().toString()
             mapOfParagraphStyleSpans[key] = value
         }


### PR DESCRIPTION
- Added support for custom spans `addSpan{}` for character and paragraph spans via `OccurrenceChunk` and global `EasySpan.Builder` in the `legacy `module.
- Introduced thread-safe handling for span maps using `ConcurrentHashMap`
- Improved span setup with validation for custom styles and error handling
- Optimized occurrence chunk setup and span application logic.
- Improved cleanup and resource management for applied spans